### PR TITLE
Doubled and supported pawns

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -131,7 +131,7 @@ namespace {
         stoppers   = theirPawns & passed_pawn_mask(Us, s);
         lever      = theirPawns & pawnAttacksBB[s];
         leverPush  = theirPawns & pawnAttacksBB[s + Up];
-        doubled    = ourPawns   & (s + Up);
+        doubled    = ourPawns   & (s - Up);
         neighbours = ourPawns   & adjacent_files_bb(f);
         phalanx    = neighbours & rank_bb(s);
         supported  = neighbours & rank_bb(s - Up);
@@ -177,8 +177,8 @@ namespace {
         if (connected)
             score += Connected[opposed][!!phalanx][more_than_one(supported)][relative_rank(Us, s)];
 
-        if (doubled)
-            score -= Doubled;
+        if (doubled && !supported)
+           score -= Doubled;
 
         if (lever)
             score += Lever[relative_rank(Us, s)];


### PR DESCRIPTION
Do not give the doubled pawn penalty when the frontmost pawn is
supported, for instance f2-g2-g3

STC:
LLR: 2.95 (-2.94,2.94) [0.00,5.00]
Total: 55927 W: 10418 L: 10052 D: 35457
http://tests.stockfishchess.org/tests/view/58eb9fc20ebc59035df33858

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,5.00]
Total: 32078 W: 4257 L: 4035 D: 23786
http://tests.stockfishchess.org/tests/view/58ec48420ebc59035df3388b

Bench: 5995472

Closes #1062